### PR TITLE
bump ark to 0.9.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs maven 2 or 3 and includes a maven resource.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.3.0'
 
-depends 'ark',  '~> 0.4'
+depends 'ark',  '~> 0.9.0'
 depends 'java', '~> 1.13'
 depends 'windows'
 


### PR DESCRIPTION
This updates the ark dependency up to v0.9.0. See my comment [here](https://github.com/opscode-cookbooks/maven/pull/37#discussion_r29954624) about how `win_install_dir` wasn't added to ark until v0.9.0. As a result, users who run this cookbook may see the issue outlined in #54.